### PR TITLE
DomainExceptionのプロパティ名を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,62 @@ SQLiteのテーブル情報を取得し、C#のDTOクラスを作成するプロ
           ```sh
           docker-compose down
           ```
+
+## テスト
+* ローカル実行  
+   * すべて実行する場合  
+        dotnet runで実行する。  
+        ```sh
+        --.NET6
+        dotnet test ./src/NET6/SQLite2DTOTest/SQLite2DTOTest.csproj
+
+        --.NET5
+        dotnet test ./src/NET5/SQLite2DTOTest/SQLite2DTOTest.csproj
+        ```  
+
+* Dockerコンテナでの実行  
+    Dockerコンテナ上で開発環境を構築する。  
+   * 前提  
+     * Docker EngineやDocker Desktopがインストール済みであること。
+
+   * 実行手順  
+     PostgreSQLコンテナとdotnetコンテナを起動する。
+      1. docker_devに移動  
+          ```sh
+          cd docker_dev
+          ```
+
+      1. (**初回のみ**)ビルド  
+          ```sh
+          docker-compose build
+          ```
+
+      1. コンテナ起動  
+          ```sh
+          docker-compose up -d
+          ```
+
+      1. コンテナに入る  
+          ```sh
+          docker exec -it docker_dev_dotnet_1 /bin/bash
+          ```
+
+      1. コンテナ内で実行 
+          1. テストを実行する。  
+              ```sh
+              --.NET6
+              dotnet test ./src/NET6/SQLite2DTOTest/SQLite2DTOTest.csproj
+
+              --.NET5
+              dotnet test ./src/NET5/SQLite2DTOTest/SQLite2DTOTest.csproj
+              ```
+
+          1. コンテナから離脱する。  
+              ```sh
+              exit
+              ```
+
+      1. コンテナ停止・削除  
+          ```sh
+          docker-compose down
+          ```

--- a/src/NET6/Application/Model/ExceptionModel.cs
+++ b/src/NET6/Application/Model/ExceptionModel.cs
@@ -53,9 +53,9 @@ namespace Application.Model
       }
       else
       {
-        // ドメインレイヤー用例外の場合はIDからメッセージを取得する
+        // ドメインレイヤー用例外の場合はメッセージを取得する
         var result = new StringBuilder();
-        foreach (var item in domainException.MessageIds)
+        foreach (var item in domainException.Messages)
         {
           result.AppendLine(GetDomainMessage(item));
         }
@@ -66,22 +66,22 @@ namespace Application.Model
     /// <summary>
     /// 例外メッセージを返す
     /// </summary>
-    /// <param name="targetAndMessageID">対象項目とメッセージIDの文字列</param>
+    /// <param name="message">対象項目とメッセージIDの文字列</param>
     /// <returns>例外メッセージ</returns>
-    private string GetDomainMessage(DomainExceptionMessage targetAndMessageID)
+    private string GetDomainMessage(DomainExceptionMessage message)
     {
-      switch (targetAndMessageID.MessageID)
+      switch (message.MessageID)
       {
         case DomainExceptionMessage.ExceptionType.Empty:
-          return $"Empty: {targetAndMessageID.Target}";
+          return $"Empty: {message.Target}";
         case DomainExceptionMessage.ExceptionType.DBError:
-          return $"DBError: {targetAndMessageID.Target}";
+          return $"DBError: {message.Target}";
         case DomainExceptionMessage.ExceptionType.ParameterError:
-          return $"parameterError: {targetAndMessageID.Target}";
+          return $"parameterError: {message.Target}";
         case DomainExceptionMessage.ExceptionType.FileOutputError:
-          return $"OutputFileError: {targetAndMessageID.Target}";
+          return $"OutputFileError: {message.Target}";
         default:
-          return $"UnknownError: {targetAndMessageID.Target}";
+          return $"UnknownError: {message.Target}";
       }
     }
   }

--- a/src/NET6/Domain/Exceptions/DomainException.cs
+++ b/src/NET6/Domain/Exceptions/DomainException.cs
@@ -11,6 +11,7 @@ namespace Domain.Exceptions
     /// <summary>
     /// メッセージIDリスト
     /// </summary>
+    [Obsolete]
     public ReadOnlyCollection<DomainExceptionMessage> MessageIds { get; private set; }
 
     /// <summary>

--- a/src/NET6/Domain/Exceptions/DomainException.cs
+++ b/src/NET6/Domain/Exceptions/DomainException.cs
@@ -9,12 +9,6 @@ namespace Domain.Exceptions
   public class DomainException : Exception
   {
     /// <summary>
-    /// メッセージIDリスト
-    /// </summary>
-    [Obsolete]
-    public ReadOnlyCollection<DomainExceptionMessage> MessageIds { get; private set; }
-
-    /// <summary>
     /// メッセージリスト
     /// </summary>
     public ReadOnlyCollection<DomainExceptionMessage> Messages { get; private set; }
@@ -22,24 +16,22 @@ namespace Domain.Exceptions
     /// <summary>
     /// コンストラクタ
     /// </summary>
-    /// <param name="messageIds">メッセージIDリスト</param>
+    /// <param name="messages">メッセージリスト</param>
     /// <remarks>Presentationで補足する場合はApplicationのExceptionModelを利用する</remarks>
-    public DomainException(ReadOnlyCollection<DomainExceptionMessage> messageIds)
+    public DomainException(ReadOnlyCollection<DomainExceptionMessage> messages)
     {
-      MessageIds = messageIds;
-      Messages = messageIds;
+      Messages = messages;
     }
 
     /// <summary>
     /// コンストラクタ
     /// </summary>
-    /// <param name="messageIds">メッセージIDリスト</param>
+    /// <param name="messages">メッセージリスト</param>
     /// <param name="innerException">内部例外エラー</param>
     /// <remarks>Presentationで補足する場合はApplicationのExceptionModelを利用する</remarks>
-    public DomainException(ReadOnlyCollection<DomainExceptionMessage> messageIds, Exception innerException) : base(innerException.Message)
+    public DomainException(ReadOnlyCollection<DomainExceptionMessage> messages, Exception innerException) : base(innerException.Message)
     {
-      MessageIds = messageIds;
-      Messages = messageIds;
+      Messages = messages;
     }
   }
 }

--- a/src/NET6/Domain/Exceptions/DomainException.cs
+++ b/src/NET6/Domain/Exceptions/DomainException.cs
@@ -14,6 +14,11 @@ namespace Domain.Exceptions
     public ReadOnlyCollection<DomainExceptionMessage> MessageIds { get; private set; }
 
     /// <summary>
+    /// メッセージリスト
+    /// </summary>
+    public ReadOnlyCollection<DomainExceptionMessage> Messages { get; private set; }
+
+    /// <summary>
     /// コンストラクタ
     /// </summary>
     /// <param name="messageIds">メッセージIDリスト</param>
@@ -21,6 +26,7 @@ namespace Domain.Exceptions
     public DomainException(ReadOnlyCollection<DomainExceptionMessage> messageIds)
     {
       MessageIds = messageIds;
+      Messages = messageIds;
     }
 
     /// <summary>
@@ -32,6 +38,7 @@ namespace Domain.Exceptions
     public DomainException(ReadOnlyCollection<DomainExceptionMessage> messageIds, Exception innerException) : base(innerException.Message)
     {
       MessageIds = messageIds;
+      Messages = messageIds;
     }
   }
 }

--- a/src/NET6/SQLite2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
+++ b/src/NET6/SQLite2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
@@ -1,11 +1,11 @@
 using Application;
 using Application.Model;
 using Domain.Exceptions;
-using SQLite2DTOTest.Shared;
+using PostgreSQL2DTOTest.Shared;
 using System;
 using Xunit;
 
-namespace SQLite2DTOTest.ApplicationTest
+namespace PostgreSQL2DTOTest.ApplicationTest
 {
   /// <summary>
   /// CSファイル作成アプリケーションサービスのテスト

--- a/src/NET6/SQLite2DTOTest/DomainTest/CSFiles/TestFileDataEntity.cs
+++ b/src/NET6/SQLite2DTOTest/DomainTest/CSFiles/TestFileDataEntity.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System;
 using Xunit;
 
-namespace SQLite2DTOTest.Domain.CSFiles
+namespace PostgreSQL2DTOTest.Domain.CSFiles
 {
   /// <summary>
   /// ファイル作成パラメータエンティティのテスト

--- a/src/NET6/SQLite2DTOTest/DomainTest/Classes/TestClassEntity.cs
+++ b/src/NET6/SQLite2DTOTest/DomainTest/Classes/TestClassEntity.cs
@@ -1,13 +1,13 @@
 using Domain.Classes;
 using Domain.Exceptions;
 using Domain.DB;
-using SQLite2DTOTest.Shared;
+using PostgreSQL2DTOTest.Shared;
 using System;
 using System.Linq;
 using System.Collections.Generic;
 using Xunit;
 
-namespace SQLite2DTOTest.Domain.Classes
+namespace PostgreSQL2DTOTest.Domain.Classes
 {
   /// <summary>
   /// クラスエンティティのテスト

--- a/src/NET6/SQLite2DTOTest/DomainTest/Classes/TestPropertyEntity.cs
+++ b/src/NET6/SQLite2DTOTest/DomainTest/Classes/TestPropertyEntity.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System;
 using Xunit;
 
-namespace SQLite2DTOTest.Domain.Classes
+namespace PostgreSQL2DTOTest.Domain.Classes
 {
   /// <summary>
   /// プロパティエンティティのテスト

--- a/src/NET6/SQLite2DTOTest/DomainTest/DB/TestDBParameterEntity.cs
+++ b/src/NET6/SQLite2DTOTest/DomainTest/DB/TestDBParameterEntity.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System;
 using Xunit;
 
-namespace SQLite2DTOTest.Domain.DB
+namespace PostgreSQL2DTOTest.Domain.DB
 {
   /// <summary>
   /// DB接続パラメータエンティティのテスト

--- a/src/NET6/SQLite2DTOTest/InfrastructureTest/TestDBRepository.cs
+++ b/src/NET6/SQLite2DTOTest/InfrastructureTest/TestDBRepository.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using Xunit;
 
-namespace SQLite2DTOTest.InfrastructureTest
+namespace PostgreSQL2DTOTest.InfrastructureTest
 {
   /// <summary>
   /// DBリポジトリのテスト
@@ -43,7 +43,6 @@ namespace SQLite2DTOTest.InfrastructureTest
     {
     }
 
-    [Fact]
     public void ExceptionDBConnect()
     {
       var classes = repository.GetClasses(DBParameterEntity.Create(FailedSQLitePath));
@@ -52,7 +51,6 @@ namespace SQLite2DTOTest.InfrastructureTest
       Assert.Empty(classes);
     }
 
-    [Fact]
     public void DBConnect()
     {
       var classes = repository.GetClasses(DBParameterEntity.Create(SQLitePath));

--- a/src/NET6/SQLite2DTOTest/Shared/MockCSFileRepository.cs
+++ b/src/NET6/SQLite2DTOTest/Shared/MockCSFileRepository.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
 
-namespace SQLite2DTOTest.Shared
+namespace PostgreSQL2DTOTest.Shared
 {
   /// <summary>
   /// CSファイル出力モックリポジトリ

--- a/src/NET6/SQLite2DTOTest/Shared/MockDBRepository.cs
+++ b/src/NET6/SQLite2DTOTest/Shared/MockDBRepository.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using Infrastructure.DB;
 
-namespace SQLite2DTOTest.Shared
+namespace PostgreSQL2DTOTest.Shared
 {
   /// <summary>
   /// DBモックリポジトリ
@@ -65,8 +65,8 @@ namespace SQLite2DTOTest.Shared
       Table tempTable = null;
 
       tempTable = new Table("m_test", "マスタテーブル");
-      tempTable.Columns.Add(new Column("int_1", "integer", "intになる"));
-      tempTable.Columns.Add(new Column("Date_1_1", "date", "Dateになる"));
+      tempTable.Columns.Add(new Column("int", "integer", "intになる"));
+      tempTable.Columns.Add(new Column("Date", "date", "Dateになる"));
       result.Add(tempTable);
 
       tempTable = new Table("t_test", "テストテーブル");

--- a/src/NET6/SQLite2DTOTest/Shared/SetTestDI.cs
+++ b/src/NET6/SQLite2DTOTest/Shared/SetTestDI.cs
@@ -2,7 +2,7 @@ using Domain.CSFiles;
 using Domain.DB;
 using TinyDIContainer;
 
-namespace SQLite2DTOTest.Shared
+namespace PostgreSQL2DTOTest.Shared
 {
   /// <summary>
   /// テスト用DI設定


### PR DESCRIPTION
DomainExceptionMessageリストのプロパティ名を
「MessageIds」から「Messages」に変更した。