### PR TITLE
プロパティの初期化とRecordの適用

### DIFF
--- a/src/NET6/Application/GenerateCSApplicationService.cs
+++ b/src/NET6/Application/GenerateCSApplicationService.cs
@@ -41,7 +41,7 @@ namespace Application
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (inputParamModel is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(inputParamModel)}[{inputParamModel}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (inputParamModel is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(inputParamModel)}[{inputParamModel}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       var classes = dbRepository.GetClasses(DBParameterEntity.Create(inputParamModel.SQLiteFilePath));

--- a/src/NET6/Application/Model/ExceptionModel.cs
+++ b/src/NET6/Application/Model/ExceptionModel.cs
@@ -72,13 +72,13 @@ namespace Application.Model
     {
       switch (message.MessageID)
       {
-        case DomainExceptionMessage.ExceptionType.Empty:
+        case ExceptionType.Empty:
           return $"Empty: {message.Target}";
-        case DomainExceptionMessage.ExceptionType.DBError:
+        case ExceptionType.DBError:
           return $"DBError: {message.Target}";
-        case DomainExceptionMessage.ExceptionType.ParameterError:
+        case ExceptionType.ParameterError:
           return $"parameterError: {message.Target}";
-        case DomainExceptionMessage.ExceptionType.FileOutputError:
+        case ExceptionType.FileOutputError:
           return $"OutputFileError: {message.Target}";
         default:
           return $"UnknownError: {message.Target}";

--- a/src/NET6/Application/Model/GeneretedFileResultsModel.cs
+++ b/src/NET6/Application/Model/GeneretedFileResultsModel.cs
@@ -5,20 +5,6 @@ namespace Application.Model
   /// <summary>
   /// 生成結果モデル
   /// </summary>
-  public class GeneretedFileResultsModel
-  {
-    /// <summary>
-    /// 生成結果メッセージ
-    /// </summary>
-    public ReadOnlyCollection<string> Messages { get; init; }
-
-    /// <summary>
-    /// コンストラクタ
-    /// </summary>
-    /// <param name="messages">生成結果メッセージ</param>
-    public GeneretedFileResultsModel(ReadOnlyCollection<string> messages)
-    {
-      Messages = messages;
-    }
-  }
+  /// <param name="Messages">生成結果メッセージ</param>
+  public record GeneretedFileResultsModel(ReadOnlyCollection<string> Messages);
 }

--- a/src/NET6/Application/Model/GeneretedFileResultsModel.cs
+++ b/src/NET6/Application/Model/GeneretedFileResultsModel.cs
@@ -10,7 +10,7 @@ namespace Application.Model
     /// <summary>
     /// 生成結果メッセージ
     /// </summary>
-    public ReadOnlyCollection<string> Messages { get; private set; }
+    public ReadOnlyCollection<string> Messages { get; init; }
 
     /// <summary>
     /// コンストラクタ

--- a/src/NET6/Application/Model/InputParamModel.cs
+++ b/src/NET6/Application/Model/InputParamModel.cs
@@ -39,9 +39,9 @@ namespace Application.Model
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(nameSpace)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(nameSpace)}[{nameSpace}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(outputPath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(outputPath)}[{outputPath}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(sqliteFilePath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(sqliteFilePath)}[{sqliteFilePath}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(nameSpace)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(nameSpace)}[{nameSpace}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(outputPath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(outputPath)}[{outputPath}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(sqliteFilePath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(sqliteFilePath)}[{sqliteFilePath}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       NameSpace = nameSpace;

--- a/src/NET6/Application/Model/InputParamModel.cs
+++ b/src/NET6/Application/Model/InputParamModel.cs
@@ -11,22 +11,22 @@ namespace Application.Model
     /// <summary>
     /// CSファイルのクラスに設定する名前空間
     /// </summary>
-    public string NameSpace { get; private set; }
+    public string NameSpace { get; init; }
 
     /// <summary>
     /// CSファイル出力先ディレクトリパス
     /// </summary>
-    public string OutputPath { get; private set; }
+    public string OutputPath { get; init; }
 
     /// <summary>
     /// DB接続情報：SQLiteファイルのパス
     /// </summary>
-    public string SQLiteFilePath { get; private set; }
+    public string SQLiteFilePath { get; init; }
 
     /// <summary>
     /// スネークケースのままとするか
     /// </summary>
-    public bool UseSnakeCase { get; private set; }
+    public bool UseSnakeCase { get; init; }
 
     /// <summary>
     /// コンストラクタ

--- a/src/NET6/Domain/CSFiles/FileDataEntity.cs
+++ b/src/NET6/Domain/CSFiles/FileDataEntity.cs
@@ -11,12 +11,12 @@ namespace Domain.CSFiles
     /// <summary>
     /// 出力パス
     /// </summary>
-    public string OutputPath { get; private set; }
+    public string OutputPath { get; init; }
 
     /// <summary>
     /// 名前空間
     /// </summary>
-    public string NameSpace { get; private set; }
+    public string NameSpace { get; init; }
 
     /// <summary>
     /// 非公開コンストラクタ

--- a/src/NET6/Domain/CSFiles/FileDataEntity.cs
+++ b/src/NET6/Domain/CSFiles/FileDataEntity.cs
@@ -35,8 +35,8 @@ namespace Domain.CSFiles
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(outputPath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(outputPath)}[{outputPath}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(nameSpace)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(nameSpace)}[{nameSpace}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(outputPath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(outputPath)}[{outputPath}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(nameSpace)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(nameSpace)}[{nameSpace}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       return new FileDataEntity()

--- a/src/NET6/Domain/Classes/ClassEntity.cs
+++ b/src/NET6/Domain/Classes/ClassEntity.cs
@@ -45,9 +45,9 @@ namespace Domain.Classes
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(name)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(name)}[{name}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(comment)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(comment)}[{comment}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (properties.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(properties)}[{properties}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(name)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(name)}[{name}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(comment)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(comment)}[{comment}]", ExceptionType.Empty));
+      if (properties.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(properties)}[{properties}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       return new ClassEntity()

--- a/src/NET6/Domain/Classes/ClassEntity.cs
+++ b/src/NET6/Domain/Classes/ClassEntity.cs
@@ -13,19 +13,19 @@ namespace Domain.Classes
     /// 名称
     /// </summary>
     /// <value>プロパティ名</value>
-    public string Name { get; private set; }
+    public string Name { get; init; }
 
     /// <summary>
     /// コメント
     /// </summary>
     /// <value>コメント文字列</value>
-    public string Comment { get; private set; }
+    public string Comment { get; init; }
 
     /// <summary>
     /// プロパティリスト
     /// </summary>
     /// <returns>プロパティリスト</returns>
-    public ReadOnlyCollection<PropertyEntity> Properties { get; private set; }
+    public ReadOnlyCollection<PropertyEntity> Properties { get; init; }
 
     /// <summary>
     /// 非公開コンストラクタ

--- a/src/NET6/Domain/Classes/PropertyEntity.cs
+++ b/src/NET6/Domain/Classes/PropertyEntity.cs
@@ -12,19 +12,19 @@ namespace Domain.Classes
     /// 名称
     /// </summary>
     /// <value>プロパティ名</value>
-    public string Name { get; private set; }
+    public string Name { get; init; }
 
     /// <summary>
     /// 型名
     /// </summary>
     /// <value>型名称</value>
-    public string TypeName { get; private set; }
+    public string TypeName { get; init; }
 
     /// <summary>
     /// コメント
     /// </summary>
     /// <value>コメント文字列</value>
-    public string Comment { get; private set; }
+    public string Comment { get; init; }
 
     /// <summary>
     /// 非公開コンストラクタ

--- a/src/NET6/Domain/Classes/PropertyEntity.cs
+++ b/src/NET6/Domain/Classes/PropertyEntity.cs
@@ -44,9 +44,9 @@ namespace Domain.Classes
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(name)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(name)}[{name}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(typeName)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(typeName)}[{typeName}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (string.IsNullOrEmpty(comment)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(comment)}[{comment}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(name)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(name)}[{name}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(typeName)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(typeName)}[{typeName}]", ExceptionType.Empty));
+      if (string.IsNullOrEmpty(comment)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(comment)}[{comment}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       return new PropertyEntity()

--- a/src/NET6/Domain/DB/DBParameterEntity.cs
+++ b/src/NET6/Domain/DB/DBParameterEntity.cs
@@ -29,7 +29,7 @@ namespace Domain.DB
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (string.IsNullOrEmpty(sqliteFilePath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(sqliteFilePath)}[{sqliteFilePath}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (string.IsNullOrEmpty(sqliteFilePath)) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(sqliteFilePath)}[{sqliteFilePath}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       return new DBParameterEntity()

--- a/src/NET6/Domain/DB/DBParameterEntity.cs
+++ b/src/NET6/Domain/DB/DBParameterEntity.cs
@@ -11,7 +11,7 @@ namespace Domain.DB
     /// <summary>
     /// DB接続情報：SQLiteファイルのパス
     /// </summary>
-    public string SQLiteFilePath { get; private set; }
+    public string SQLiteFilePath { get; init; }
 
     /// <summary>
     /// 非公開コンストラクタ

--- a/src/NET6/Domain/Exceptions/DomainException.cs
+++ b/src/NET6/Domain/Exceptions/DomainException.cs
@@ -11,7 +11,7 @@ namespace Domain.Exceptions
     /// <summary>
     /// メッセージリスト
     /// </summary>
-    public ReadOnlyCollection<DomainExceptionMessage> Messages { get; private set; }
+    public ReadOnlyCollection<DomainExceptionMessage> Messages { get; init; }
 
     /// <summary>
     /// コンストラクタ

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -14,27 +14,7 @@ namespace Domain.Exceptions
   /// <summary>
   /// ドメインレイヤー用例外クラス メッセージクラス
   /// </summary>
-  public class DomainExceptionMessage
-  {
-    /// <summary>
-    /// 対象項目
-    /// </summary>
-    public string Target { get; init; }
-
-    /// <summary>
-    /// メッセージID
-    /// </summary>
-    public ExceptionType MessageID { get; init; }
-
-    /// <summary>
-    /// コンストラクタ
-    /// </summary>
-    /// <param name="target">対象項目</param>
-    /// <param name="messageId">メッセージID</param>
-    public DomainExceptionMessage(string target, ExceptionType messageId)
-    {
-      Target = target;
-      MessageID = messageId;
-    }
-  }
+  /// <param name="Target">対象項目</param>
+  /// <param name="MessageID">メッセージID</param>
+  public record DomainExceptionMessage(string Target, ExceptionType MessageID);
 }

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -1,6 +1,17 @@
 namespace Domain.Exceptions
 {
   /// <summary>
+  /// 例外種別
+  /// </summary>
+  public enum ExceptionType
+  {
+    Empty,
+    ParameterError,
+    DBError,
+    FileOutputError
+  }
+
+  /// <summary>
   /// ドメインレイヤー用例外クラス メッセージクラス
   /// </summary>
   public class DomainExceptionMessage

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -6,11 +6,6 @@ namespace Domain.Exceptions
   public class DomainExceptionMessage
   {
     /// <summary>
-    /// 区切り文字
-    /// </summary>
-    public const string Delimiter = ":";
-
-    /// <summary>
     /// 例外種別
     /// </summary>
     public enum ExceptionType

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -19,6 +19,7 @@ namespace Domain.Exceptions
     /// <summary>
     /// 例外種別
     /// </summary>
+    [System.Obsolete]
     public enum ExceptionType
     {
       Empty,

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -25,12 +25,12 @@ namespace Domain.Exceptions
     /// <summary>
     /// 対象項目
     /// </summary>
-    public string Target { get; private set; }
+    public string Target { get; init; }
 
     /// <summary>
     /// メッセージID
     /// </summary>
-    public ExceptionType MessageID { get; private set; }
+    public ExceptionType MessageID { get; init; }
 
     /// <summary>
     /// コンストラクタ

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -17,20 +17,6 @@ namespace Domain.Exceptions
   public class DomainExceptionMessage
   {
     /// <summary>
-    /// 例外種別
-    /// </summary>
-    /// <remark>一時的に改名</remark>
-    [System.Obsolete]
-    public enum ExceptionTypes
-    {
-      Empty,
-      ParameterError,
-      DBError,
-      FileOutputError
-    }
-
-
-    /// <summary>
     /// 対象項目
     /// </summary>
     public string Target { get; init; }

--- a/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
+++ b/src/NET6/Domain/Exceptions/DomainExceptionMessage.cs
@@ -19,8 +19,9 @@ namespace Domain.Exceptions
     /// <summary>
     /// 例外種別
     /// </summary>
+    /// <remark>一時的に改名</remark>
     [System.Obsolete]
-    public enum ExceptionType
+    public enum ExceptionTypes
     {
       Empty,
       ParameterError,

--- a/src/NET6/Infrastructure/CSFiles/CSFileRepository.cs
+++ b/src/NET6/Infrastructure/CSFiles/CSFileRepository.cs
@@ -26,8 +26,8 @@ namespace Infrastructure.CSFiles
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (classEntities.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(classEntities)}[{classEntities}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (fileDataEntity is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(fileDataEntity)}[{fileDataEntity}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (classEntities.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(classEntities)}[{classEntities}]", ExceptionType.Empty));
+      if (fileDataEntity is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(fileDataEntity)}[{fileDataEntity}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       var result = new List<string>();
@@ -56,7 +56,7 @@ namespace Infrastructure.CSFiles
       catch (System.Exception ex)
       {
         var messages = new List<DomainExceptionMessage>();
-        messages.Add(new DomainExceptionMessage($"{ex.Message}", DomainExceptionMessage.ExceptionType.FileOutputError));
+        messages.Add(new DomainExceptionMessage($"{ex.Message}", ExceptionType.FileOutputError));
         throw new DomainException(messages.AsReadOnly(), ex);
       }
 

--- a/src/NET6/Infrastructure/CSFiles/Templates/CreateCS.cs
+++ b/src/NET6/Infrastructure/CSFiles/Templates/CreateCS.cs
@@ -31,7 +31,7 @@ namespace Infrastructure.CSFiles.Templates
     /// <summary>
     /// namespace
     /// </summary>
-    public string NameSpace { private set; get; }
+    public string NameSpace { init; get; }
 
 
     /// <summary>
@@ -42,7 +42,7 @@ namespace Infrastructure.CSFiles.Templates
     /// <summary>
     /// スネークケースのままとするか
     /// </summary>
-    public bool UseSnakeCase { get; private set; }
+    public bool UseSnakeCase { get; init; }
 
     /// <summary>
     /// テーブル名やカラム名からC#用名称を取得

--- a/src/NET6/Infrastructure/CSFiles/Templates/CreateCS.tt
+++ b/src/NET6/Infrastructure/CSFiles/Templates/CreateCS.tt
@@ -14,7 +14,7 @@ namespace <#= NameSpace #>
     }
 
     <# 
-    foreach (var property in classEntity.Properties)
+    foreach(var property in classEntity.Properties)
     {
     #>
     <#= GetCSComment(property.Comment, "    ") #>

--- a/src/NET6/Infrastructure/DB/DBRepository.cs
+++ b/src/NET6/Infrastructure/DB/DBRepository.cs
@@ -51,7 +51,7 @@ namespace Infrastructure.DB
       catch (Exception exception)
       {
         var exceptionMessages = new List<DomainExceptionMessage>();
-        exceptionMessages.Add(new DomainExceptionMessage($"{connectionString}", DomainExceptionMessage.ExceptionType.DBError));
+        exceptionMessages.Add(new DomainExceptionMessage($"{connectionString}", ExceptionType.DBError));
         throw new DomainException(exceptionMessages.AsReadOnly(), exception);
       }
 

--- a/src/NET6/SQLite2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
+++ b/src/NET6/SQLite2DTOTest/ApplicationTest/TestGenerateCSApplicationService.cs
@@ -1,11 +1,11 @@
 using Application;
 using Application.Model;
 using Domain.Exceptions;
-using PostgreSQL2DTOTest.Shared;
+using SQLite2DTOTest.Shared;
 using System;
 using Xunit;
 
-namespace PostgreSQL2DTOTest.ApplicationTest
+namespace SQLite2DTOTest.ApplicationTest
 {
   /// <summary>
   /// CSファイル作成アプリケーションサービスのテスト
@@ -38,7 +38,7 @@ namespace PostgreSQL2DTOTest.ApplicationTest
     {
       var ex = Assert.ThrowsAny<DomainException>(() => applicationService.GenerateCSFileFromDB(null));
       Assert.Single(ex.Messages);
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("inputParamModel[]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/SQLite2DTOTest/DomainTest/CSFiles/TestFileDataEntity.cs
+++ b/src/NET6/SQLite2DTOTest/DomainTest/CSFiles/TestFileDataEntity.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System;
 using Xunit;
 
-namespace PostgreSQL2DTOTest.Domain.CSFiles
+namespace SQLite2DTOTest.Domain.CSFiles
 {
   /// <summary>
   /// ファイル作成パラメータエンティティのテスト
@@ -34,10 +34,10 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
       Assert.Equal(2, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("outputPath[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[1].MessageID);
       Assert.Equal("nameSpace[]", ex.Messages[1].Target);
     }
 
@@ -50,7 +50,7 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("outputPath[]", ex.Messages[0].Target);
     }
 
@@ -63,7 +63,7 @@ namespace PostgreSQL2DTOTest.Domain.CSFiles
       var ex = Assert.ThrowsAny<DomainException>(() => FileDataEntity.Create(outputPath, nameSpace));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("nameSpace[]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/SQLite2DTOTest/DomainTest/Classes/TestClassEntity.cs
+++ b/src/NET6/SQLite2DTOTest/DomainTest/Classes/TestClassEntity.cs
@@ -1,13 +1,13 @@
 using Domain.Classes;
 using Domain.Exceptions;
 using Domain.DB;
-using PostgreSQL2DTOTest.Shared;
+using SQLite2DTOTest.Shared;
 using System;
 using System.Linq;
 using System.Collections.Generic;
 using Xunit;
 
-namespace PostgreSQL2DTOTest.Domain.Classes
+namespace SQLite2DTOTest.Domain.Classes
 {
   /// <summary>
   /// クラスエンティティのテスト
@@ -49,13 +49,13 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
       Assert.Equal(3, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("name[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[1].MessageID);
       Assert.Equal("comment[]", ex.Messages[1].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[2].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[2].MessageID);
       Assert.Equal($"properties[{properties.AsReadOnly()}]", ex.Messages[2].Target);
     }
 
@@ -69,7 +69,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("name[]", ex.Messages[0].Target);
     }
 
@@ -83,7 +83,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("comment[]", ex.Messages[0].Target);
     }
 
@@ -97,7 +97,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => ClassEntity.Create(name, comment, properties.AsReadOnly()));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal($"properties[{properties.AsReadOnly()}]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/SQLite2DTOTest/DomainTest/Classes/TestPropertyEntity.cs
+++ b/src/NET6/SQLite2DTOTest/DomainTest/Classes/TestPropertyEntity.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System;
 using Xunit;
 
-namespace PostgreSQL2DTOTest.Domain.Classes
+namespace SQLite2DTOTest.Domain.Classes
 {
   /// <summary>
   /// プロパティエンティティのテスト
@@ -35,13 +35,13 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
       Assert.Equal(3, ex.Messages.Count);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("name[]", ex.Messages[0].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[1].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[1].MessageID);
       Assert.Equal("typeName[]", ex.Messages[1].Target);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[2].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[2].MessageID);
       Assert.Equal("comment[]", ex.Messages[2].Target);
     }
 
@@ -55,7 +55,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("name[]", ex.Messages[0].Target);
     }
 
@@ -69,7 +69,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("typeName[]", ex.Messages[0].Target);
     }
 
@@ -83,7 +83,7 @@ namespace PostgreSQL2DTOTest.Domain.Classes
       var ex = Assert.ThrowsAny<DomainException>(() => PropertyEntity.Create(name, typeName, comment));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("comment[]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/SQLite2DTOTest/DomainTest/DB/TestDBParameterEntity.cs
+++ b/src/NET6/SQLite2DTOTest/DomainTest/DB/TestDBParameterEntity.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System;
 using Xunit;
 
-namespace PostgreSQL2DTOTest.Domain.DB
+namespace SQLite2DTOTest.Domain.DB
 {
   /// <summary>
   /// DB接続パラメータエンティティのテスト
@@ -33,7 +33,7 @@ namespace PostgreSQL2DTOTest.Domain.DB
       var ex = Assert.ThrowsAny<DomainException>(() => DBParameterEntity.Create(sqlitePath));
       Assert.Single(ex.Messages);
 
-      Assert.Equal(DomainExceptionMessage.ExceptionType.Empty, ex.Messages[0].MessageID);
+      Assert.Equal(ExceptionType.Empty, ex.Messages[0].MessageID);
       Assert.Equal("sqliteFilePath[]", ex.Messages[0].Target);
     }
 

--- a/src/NET6/SQLite2DTOTest/InfrastructureTest/TestCSFileRepository.cs
+++ b/src/NET6/SQLite2DTOTest/InfrastructureTest/TestCSFileRepository.cs
@@ -3,14 +3,14 @@ using Domain.CSFiles;
 using Domain.DB;
 using Domain.Exceptions;
 using Infrastructure.CSFiles;
-using PostgreSQL2DTOTest.Shared;
+using SQLite2DTOTest.Shared;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace PostgreSQL2DTOTest.InfrastructureTest
+namespace SQLite2DTOTest.InfrastructureTest
 {
   /// <summary>
   /// CSファイル出力リポジトリのテスト
@@ -28,8 +28,6 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
     public TestCSFileRepository()
     {
       repository = new CSFileRepository();
-
-      Directory.CreateDirectory("CSOutputs");
     }
 
     /// <summary>
@@ -37,9 +35,9 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
     /// </summary>
     public void Dispose()
     {
-      Directory.Delete("CSOutputs", true);
     }
 
+    [Fact]
     public void ExceptionAllNG()
     {
       var classEntities = new List<ClassEntity>();
@@ -50,6 +48,7 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       Assert.Equal(2, ex.Messages.Count);
     }
 
+    [Fact]
     public void ExceptionClassEntityZero()
     {
       var classEntities = new List<ClassEntity>();
@@ -60,6 +59,7 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       Assert.Single(ex.Messages);
     }
 
+    [Fact]
     public void ExceptionFileDataEntityNull()
     {
       var mockDBRepository = new MockDBRepository();
@@ -71,11 +71,13 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       Assert.Single(ex.Messages);
     }
 
+    [Fact]
     public void CreateFiles()
     {
+      var csOutputName = "CSOutputs";
       var mockDBRepository = new MockDBRepository();
       var classEntities = mockDBRepository.GetClasses(DBParameterEntity.Create("SQLitePath"));
-      var fileDataEntity = FileDataEntity.Create("CSOutputs", "DB.Dto");
+      var fileDataEntity = FileDataEntity.Create(csOutputName, "DB.Dto");
       var useSnakeCase = false;
 
       var messages = repository.Generate(classEntities, fileDataEntity, useSnakeCase);
@@ -87,6 +89,117 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       Assert.Equal(2, fileNames.Count);
       Assert.Equal($"{Path.Combine(fileDataEntity.OutputPath,"MTest.cs")}", fileNames[0]);
       Assert.Equal($"{Path.Combine(fileDataEntity.OutputPath,"TTest.cs")}", fileNames[1]);
+      
+      // テスト終了後にフォルダ削除
+      Directory.Delete(csOutputName, true);
+    }
+
+    [Fact]
+    public void CheckFileClassNotUseSnake()
+    {
+      var csOutputName = "CSOutputs2";
+
+      var mockDBRepository = new MockDBRepository();
+      var classEntities = mockDBRepository.GetClasses(DBParameterEntity.Create("SQLitePath"));
+      var fileDataEntity = FileDataEntity.Create(csOutputName, "DB.Dto");
+      var useSnakeCase = false;
+
+      repository.Generate(classEntities, fileDataEntity, useSnakeCase);
+
+      var fileNames = Directory.GetFiles(fileDataEntity.OutputPath).Where(filename => filename == $"{Path.Combine(fileDataEntity.OutputPath, "MTest.cs")}").ToList();
+      Assert.Single(fileNames);
+
+      var actual = string.Empty;
+      using (StreamReader sr = new StreamReader(fileNames[0]))
+      {
+        actual = sr.ReadToEnd();
+      }
+
+      var expected = @"using System.ComponentModel.DataAnnotations.Schema;
+namespace DB.Dto
+{
+  /// <summary>
+  /// マスタテーブル
+  /// </summary>
+  public class MTest
+  {
+    public MTest()
+    {
+    }
+    
+    /// <summary>
+    /// intになる
+    /// </summary>
+    [Column(""int_1"")]
+    public int Int1{set; get;}
+    
+    /// <summary>
+    /// Dateになる
+    /// </summary>
+    [Column(""Date_1_1"")]
+    public DateTime Date11{set; get;}
+  }
+}
+";
+
+      Assert.Equal(expected, actual);
+
+      // テスト終了後にフォルダ削除
+      Directory.Delete(csOutputName, true);
+    }
+
+    [Fact]
+    public void CheckFileClassUseSnake()
+    {
+      var csOutputName = "CSOutputs3";
+
+      var mockDBRepository = new MockDBRepository();
+      var classEntities = mockDBRepository.GetClasses(DBParameterEntity.Create("SQLitePath"));
+      var fileDataEntity = FileDataEntity.Create(csOutputName, "DB.Dto");
+      var useSnakeCase = true;
+
+      repository.Generate(classEntities, fileDataEntity, useSnakeCase);
+
+      var fileNames = Directory.GetFiles(fileDataEntity.OutputPath).Where(filename => filename == $"{Path.Combine(fileDataEntity.OutputPath, "MTest.cs")}").ToList();
+      Assert.Single(fileNames);
+
+      var actual = string.Empty;
+      using (StreamReader sr = new StreamReader(fileNames[0]))
+      {
+        actual = sr.ReadToEnd();
+      }
+
+      var expected = @"using System.ComponentModel.DataAnnotations.Schema;
+namespace DB.Dto
+{
+  /// <summary>
+  /// マスタテーブル
+  /// </summary>
+  public class MTest
+  {
+    public MTest()
+    {
+    }
+    
+    /// <summary>
+    /// intになる
+    /// </summary>
+    [Column(""int_1"")]
+    public int Int1{set; get;}
+    
+    /// <summary>
+    /// Dateになる
+    /// </summary>
+    [Column(""Date_1_1"")]
+    public DateTime Date1_1{set; get;}
+  }
+}
+";
+
+      Assert.Equal(expected, actual);
+
+      // テスト終了後にフォルダ削除
+      Directory.Delete(csOutputName, true);
     }
   }
 }

--- a/src/NET6/SQLite2DTOTest/InfrastructureTest/TestDBRepository.cs
+++ b/src/NET6/SQLite2DTOTest/InfrastructureTest/TestDBRepository.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using Xunit;
 
-namespace PostgreSQL2DTOTest.InfrastructureTest
+namespace SQLite2DTOTest.InfrastructureTest
 {
   /// <summary>
   /// DBリポジトリのテスト
@@ -43,6 +43,7 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
     {
     }
 
+    [Fact]
     public void ExceptionDBConnect()
     {
       var classes = repository.GetClasses(DBParameterEntity.Create(FailedSQLitePath));
@@ -51,6 +52,7 @@ namespace PostgreSQL2DTOTest.InfrastructureTest
       Assert.Empty(classes);
     }
 
+    [Fact]
     public void DBConnect()
     {
       var classes = repository.GetClasses(DBParameterEntity.Create(SQLitePath));

--- a/src/NET6/SQLite2DTOTest/Shared/MockCSFileRepository.cs
+++ b/src/NET6/SQLite2DTOTest/Shared/MockCSFileRepository.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
 
-namespace PostgreSQL2DTOTest.Shared
+namespace SQLite2DTOTest.Shared
 {
   /// <summary>
   /// CSファイル出力モックリポジトリ
@@ -24,8 +24,8 @@ namespace PostgreSQL2DTOTest.Shared
     {
       // パラメーターチェック
       var exceptionMessages = new List<DomainExceptionMessage>();
-      if (classEntities.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(classEntities)}[{classEntities}]", DomainExceptionMessage.ExceptionType.Empty));
-      if (fileDataEntity is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(fileDataEntity)}[{fileDataEntity}]", DomainExceptionMessage.ExceptionType.Empty));
+      if (classEntities.Count == 0) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(classEntities)}[{classEntities}]", ExceptionType.Empty));
+      if (fileDataEntity is null) exceptionMessages.Add(new DomainExceptionMessage($"{nameof(fileDataEntity)}[{fileDataEntity}]", ExceptionType.Empty));
       if (exceptionMessages.Count > 0) throw new DomainException(exceptionMessages.AsReadOnly());
 
       var result = new List<string>();
@@ -44,7 +44,7 @@ namespace PostgreSQL2DTOTest.Shared
       catch (System.Exception ex)
       {
         var messages = new List<DomainExceptionMessage>();
-        messages.Add(new DomainExceptionMessage($"{ex.Message}", DomainExceptionMessage.ExceptionType.FileOutputError));
+        messages.Add(new DomainExceptionMessage($"{ex.Message}", ExceptionType.FileOutputError));
         throw new DomainException(messages.AsReadOnly(), ex);
       }
 

--- a/src/NET6/SQLite2DTOTest/Shared/MockDBRepository.cs
+++ b/src/NET6/SQLite2DTOTest/Shared/MockDBRepository.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using Infrastructure.DB;
 
-namespace PostgreSQL2DTOTest.Shared
+namespace SQLite2DTOTest.Shared
 {
   /// <summary>
   /// DBモックリポジトリ
@@ -39,7 +39,7 @@ namespace PostgreSQL2DTOTest.Shared
       catch (Exception exception)
       {
         var exceptionMessages = new List<DomainExceptionMessage>();
-        exceptionMessages.Add(new DomainExceptionMessage($"{connectionString}", DomainExceptionMessage.ExceptionType.DBError));
+        exceptionMessages.Add(new DomainExceptionMessage($"{connectionString}", ExceptionType.DBError));
         throw new DomainException(exceptionMessages.AsReadOnly(), exception);
       }
 
@@ -65,8 +65,8 @@ namespace PostgreSQL2DTOTest.Shared
       Table tempTable = null;
 
       tempTable = new Table("m_test", "マスタテーブル");
-      tempTable.Columns.Add(new Column("int", "integer", "intになる"));
-      tempTable.Columns.Add(new Column("Date", "date", "Dateになる"));
+      tempTable.Columns.Add(new Column("int_1", "integer", "intになる"));
+      tempTable.Columns.Add(new Column("Date_1_1", "date", "Dateになる"));
       result.Add(tempTable);
 
       tempTable = new Table("t_test", "テストテーブル");

--- a/src/NET6/SQLite2DTOTest/Shared/SetTestDI.cs
+++ b/src/NET6/SQLite2DTOTest/Shared/SetTestDI.cs
@@ -2,7 +2,7 @@ using Domain.CSFiles;
 using Domain.DB;
 using TinyDIContainer;
 
-namespace PostgreSQL2DTOTest.Shared
+namespace SQLite2DTOTest.Shared
 {
   /// <summary>
   /// テスト用DI設定


### PR DESCRIPTION
プロパティの初期化する際に「private set」していたが、
C#9.0から初期化時のみ有効な「init」が設定できるようになった。
また、単純なクラスであればRecord型で十分である。
それらを適用した。